### PR TITLE
Proxied search queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.1.0 - Unreleased
+
+ - Initial support for proxied search query \#9
+
 ### 1.0.1 (2019-Feb-13)
 
  - fix returning metadata of packages with no dependencies \#8

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Not implemented:
  * Does not work with older paket versions
  * Cache package metadata and invalidates when upstream changes are detected using [NuGet.CatalogReader](https://github.com/emgarten/NuGet.CatalogReader). *This will be ported from older liget < 1.0.0.*
  * V2 search, filter and alike queries. *This is not planned.*
- * search and autocomplete endpoints for cached packages. Basically, you need to query nuget.org to *search* for public packages.
 
 # Usage
 

--- a/src/LiGet/Cache/CacheService.cs
+++ b/src/LiGet/Cache/CacheService.cs
@@ -148,5 +148,10 @@ namespace LiGet.Cache
             //TODO: possibly cache and stream from in-memory cache
             return _sourceRepository.GetMetadataAsync(identity, CancellationToken.None);
         }
+
+        public Task<IEnumerable<IPackageSearchMetadata>> SearchAsync(string searchTerm, SearchFilter filter, int skip, int take, CancellationToken ct)
+        {
+            return _sourceRepository.SearchAsync(searchTerm, filter, skip, take, ct);
+        }
     }
 }

--- a/src/LiGet/Cache/FakeCacheService.cs
+++ b/src/LiGet/Cache/FakeCacheService.cs
@@ -57,5 +57,10 @@ namespace LiGet.Cache
         {
             return Task.CompletedTask;
         }
+
+        public Task<IEnumerable<IPackageSearchMetadata>> SearchAsync(string searchTerm, SearchFilter filter, int skip, int take, CancellationToken ct)
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }

--- a/src/LiGet/Cache/ICacheService.cs
+++ b/src/LiGet/Cache/ICacheService.cs
@@ -30,5 +30,7 @@ namespace LiGet.Cache
         Task<Stream> GetNuspecStreamAsync(PackageIdentity identity);
         Task<Stream> GetReadmeStreamAsync(PackageIdentity identity);
         Task<IPackageSearchMetadata> FindAsync(PackageIdentity identity);
+
+        Task<IEnumerable<IPackageSearchMetadata>> SearchAsync(string searchTerm, SearchFilter filter, int skip, int take, CancellationToken ct);
     }
 }

--- a/src/LiGet/CarterModules/CacheIndexModule.cs
+++ b/src/LiGet/CarterModules/CacheIndexModule.cs
@@ -39,6 +39,7 @@ namespace LiGet.CarterModules
                     Version = "3.0.0",
                     Resources =
                         ServiceWithAliases("PackagePublish", req.PackagePublish(prefix), "2.0.0") // api.nuget.org returns this too.
+                        .Concat(ServiceWithAliases("SearchQueryService", req.PackageSearch(prefix), "", "3.0.0-beta", "3.0.0-rc")) // each version is an alias of others
                         .Concat(ServiceWithAliases("RegistrationsBaseUrl", req.RegistrationsBase(prefix), "", "3.0.0-rc", "3.0.0-beta"))
                         .Concat(ServiceWithAliases("PackageBaseAddress", req.PackageBase(prefix), "3.0.0"))
                         .ToList()

--- a/src/LiGet/CarterModules/CacheSearchModule.cs
+++ b/src/LiGet/CarterModules/CacheSearchModule.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using System.Threading;
+using Carter;
+using Carter.ModelBinding;
+using Carter.Request;
+using Carter.Response;
+using LiGet.Cache;
+using LiGet.Configuration;
+using LiGet.WebModels;
+using NuGet.Protocol.Core.Types;
+
+namespace LiGet.CarterModules
+{
+    public class CacheSearchModule : CarterModule
+    {
+        const string prefix = "api/cache";
+
+        public CacheSearchModule(ICacheService cacheService) {
+            this.Get("/api/cache/v3/search", async (req, res, routeData) => {
+                var query = req.Query.As<string>("q");
+                int? skip = req.Query.As<int?>("skip");
+                int? take = req.Query.As<int?>("take");
+                bool? prerelease = req.Query.As<bool?>("prerelease");
+                string semVerLevel = req.Query.As<string>("semVerLevel");
+                query = query ?? string.Empty;
+
+                var results = await cacheService.SearchAsync(query, new SearchFilter(prerelease ?? false), skip ?? 0, take ?? 0, CancellationToken.None);
+                await res.AsJson(new
+                {
+                    TotalHits = results.Count(),
+                    Data = results.Select(r => new SearchResultModel(r, r.GetVersionsAsync().Result, req, prefix))
+                });
+            });
+        }
+    }
+}

--- a/src/LiGet/ISourceRepository.cs
+++ b/src/LiGet/ISourceRepository.cs
@@ -13,6 +13,7 @@ namespace LiGet
         Task<IEnumerable<IPackageSearchMetadata>> GetMetadataAsync(string packageId, bool includePrerelease, bool includeUnlisted, CancellationToken ct);
         Task<IEnumerable<NuGetVersion>> GetAllVersionsAsync(string id, CancellationToken ct);
         Task<Uri> GetPackageUriAsync(string id, string version, CancellationToken cancellationToken);
-        Task<IPackageSearchMetadata> GetMetadataAsync(PackageIdentity identity, CancellationToken none);
+        Task<IPackageSearchMetadata> GetMetadataAsync(PackageIdentity identity, CancellationToken ct);
+        Task<IEnumerable<IPackageSearchMetadata>> SearchAsync(string searchTerm, SearchFilter filter, int skip, int take, CancellationToken ct);
     }
 }

--- a/src/LiGet/NuGetClient.cs
+++ b/src/LiGet/NuGetClient.cs
@@ -40,6 +40,7 @@ namespace LiGet
             private RegistrationResourceV3 _regResource;
             private PackageMetadataResourceV3 _metadataSearch;
             private RemoteV3FindPackageByIdResource _versionSearch;
+            private PackageSearchResourceV3 _search;
             private NuGetLoggerAdapter<NuGetClient> _loggerAdapter;
 
             public NuRepository(List<Lazy<INuGetResourceProvider>> providers, Uri repositoryUrl, Microsoft.Extensions.Logging.ILogger<NuGetClient> logger)
@@ -55,6 +56,8 @@ namespace LiGet
                 ReportAbuseResourceV3 reportAbuseResource = _sourceRepository.GetResource<ReportAbuseResourceV3>();
                 _metadataSearch = new PackageMetadataResourceV3(httpSource.HttpSource, _regResource, reportAbuseResource);
                 _versionSearch = new RemoteV3FindPackageByIdResource(_sourceRepository, httpSource.HttpSource);
+                RawSearchResourceV3 rawSearchResource = _sourceRepository.GetResource<RawSearchResourceV3>();
+                _search = new PackageSearchResourceV3(rawSearchResource, _metadataSearch);
                 this._loggerAdapter = new NuGetLoggerAdapter<NuGetClient>(logger);
             }
 
@@ -99,6 +102,11 @@ namespace LiGet
             public Task<IPackageSearchMetadata> GetMetadataAsync(PackageIdentity identity, CancellationToken ct)
             {
                 return _metadataSearch.GetMetadataAsync(identity, _cacheContext, _loggerAdapter, ct);
+            }
+
+            public Task<IEnumerable<IPackageSearchMetadata>> SearchAsync(string searchTerm, SearchFilter filter, int skip, int take, CancellationToken ct)
+            {
+                return _search.SearchAsync(searchTerm, filter, skip, take, _loggerAdapter, ct);
             }
         }
     }

--- a/src/LiGet/Services/ISearchService.cs
+++ b/src/LiGet/Services/ISearchService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using LiGet.Entities;
+using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
 namespace LiGet.Services
@@ -17,6 +18,31 @@ namespace LiGet.Services
 
     public class SearchResult
     {
+        public SearchResult()
+        {
+        }
+
+        public SearchResult(IPackageSearchMetadata result, IEnumerable<VersionInfo> versions)
+        {
+            this.Id = result.Identity.Id;
+            this.Version = result.Identity.Version;
+            this.Description = result.Description;
+            this.Authors = result.Authors;
+            this.IconUrl = result.IconUrl?.AbsoluteUri;
+            this.LicenseUrl = result.LicenseUrl?.AbsoluteUri;
+            this.ProjectUrl = result.ProjectUrl?.AbsoluteUri;
+            this.Summary = result.Summary;
+            if(result.Tags != null)
+                this.Tags = result.Tags.Split(',');
+            this.Title = result.Title;
+            this.TotalDownloads = result.DownloadCount ?? 0;
+            var list  = new List<SearchResultVersion>();
+            foreach(var v in versions) {
+                list.Add(new SearchResultVersion(v));
+            }
+            this.Versions = list;
+        }
+
         public string Id { get; set; }
 
         public NuGetVersion Version { get; set; }
@@ -36,6 +62,13 @@ namespace LiGet.Services
 
     public class SearchResultVersion
     {
+
+        public SearchResultVersion(VersionInfo v)
+        {
+            this.Version = v.Version;
+            this.Downloads = v.DownloadCount ?? 0;
+        }
+
         public SearchResultVersion(NuGetVersion version, long downloads)
         {
             Version = version ?? throw new ArgumentNullException(nameof(version));

--- a/src/LiGet/WebModels/SearchResultModel.cs
+++ b/src/LiGet/WebModels/SearchResultModel.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using LiGet.Services;
 using LiGet.Extensions;
 using Microsoft.AspNetCore.Http;
+using NuGet.Protocol.Core.Types;
 
 namespace LiGet.WebModels
 {
@@ -25,6 +26,18 @@ namespace LiGet.WebModels
                     v.Downloads));
 
             Versions = versions.ToList().AsReadOnly();
+        }
+
+        public SearchResultModel(IPackageSearchMetadata result, IEnumerable<VersionInfo> versions, HttpRequest url, string prefix)
+        {
+            _result = new SearchResult(result, versions);
+            _url = url ?? throw new ArgumentNullException(nameof(url));
+            this._prefix = prefix;
+            Versions = _result.Versions.Select(
+                v => new SearchResultVersionModel(
+                    url.PackageRegistration(_result.Id, v.Version.ToNormalizedString()),
+                    v.Version.ToNormalizedString(),
+                    v.Downloads)).ToList();
         }
 
         public string Id => _result.Id;

--- a/tests/LiGet.Tests/NuGetClientIntegrationTest.cs
+++ b/tests/LiGet.Tests/NuGetClientIntegrationTest.cs
@@ -141,7 +141,7 @@ namespace LiGet.Tests
         }
 
         [Theory]
-        [MemberData(nameof(V3CasesExcludingCache))]
+        [MemberData(nameof(V3Cases))]
         public async Task IndexIncludesAtLeastOneSearchQueryEntry(string indexEndpoint)
         {
             InitializeClient(indexEndpoint);
@@ -333,6 +333,19 @@ namespace LiGet.Tests
             Assert.NotEmpty(found);
             var one = found.First();
             Assert.Equal(new PackageIdentity("liget-test1", NuGetVersion.Parse("1.0.0")), one.Identity);
+        }
+
+        [Fact]
+        [Trait("Category", "integration")] // because it queries nuget.org
+        public async Task CacheSearchPackage()
+        {
+            InitializeClient(CacheIndex);
+            var packageResource = await _sourceRepository.GetResourceAsync<PackageUpdateResource>();
+            PackageSearchResourceV3 search = GetSearch();
+            var found = await search.SearchAsync("log4net", new SearchFilter(true), 0, 10, logger, CancellationToken.None);
+            Assert.NotEmpty(found);
+            var one = found.First();
+            Assert.Equal("log4net", one.Identity.Id);
         }
 
         private PackageSearchResourceV3 GetSearch()


### PR DESCRIPTION
### What does this PR do?

Adds endpoint `http://localhost:9011/api/cache/v3/search?q=NuGet.Versioning&prerelase=true` which actually proxies the requests to nuget.org.

### ReletedIssue(s)

#9

